### PR TITLE
Enable experimental APIs on FF74+

### DIFF
--- a/src/tape-ext.js
+++ b/src/tape-ext.js
@@ -103,6 +103,7 @@ const work = async () => {
   const capabilities = new Capabilities().set("marionette", true)
   const options = new firefox.Options()
     .setPreference("log", "{level: info}")
+    .setPreference("extensions.experiments.enabled", true)
     .setBinary(binary)
     .setLoggingPrefs(log)
 


### PR DESCRIPTION
Since Firefox 74 the `extensions.experiments.enabled` pref is required for experimental APIs to be loaded. This PR sets the pref so that libdweb tests can be run against this browser versions.